### PR TITLE
Fixed wrong URL being passed for git profiles

### DIFF
--- a/src/components/About/About.js
+++ b/src/components/About/About.js
@@ -79,7 +79,8 @@ const About = () => {
               <h3>CONTRIBUTORS</h3>
             </div>
             {contributors.map((contributor) => {
-              const { contributions, avatar_url, login, type } = contributor;
+              const { contributions, avatar_url, login, type, html_url } =
+                contributor;
               return (
                 <div className="contributors_block">
                   <div className="contributor_individual">
@@ -87,13 +88,15 @@ const About = () => {
                       <img src={avatar_url} alt="contributor avatar" />
                     </div>
                     <div className="contributor_detail">
-                      <a href="https://github.com/stephin007">{login}</a>
+                      <a href={html_url}>{login}</a>
                       <div className="contribution_count">
                         <p>No of Contributions : </p>
                         <strong>{contributions}</strong>
                       </div>
                       <div className="contributor_type">
-                        {login === "stephin007" || login === "Justinnn07" ? (
+                        {login === "stephin007" ||
+                        login === "Justinnn07" ||
+                        login === "wise-introvert" ? (
                           <p>Maintainer</p>
                         ) : (
                           <p>{type}</p>


### PR DESCRIPTION
> 🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

### Please check if the PR fulfills these requirements

- [x] Make sure you are requesting to **NEW-UI**. Don't request other protected Branches like **staging/master**
- [x] Make sure no conflicts are present in the code, if so please resolve it(_Tip: Always fetch upstream_)
- [x] Your Commit messages should make sense.
- [x] Don't push your package.lock.json as this project uses yarn.lock already.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Describe your changes

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix

- **What is the current behavior?** (You can also link to an open issue here)
Right now in the about page, when clicked on contributor name, it was hardcoded to point to a single URL.

- **What is the new behavior (if this is a feature change)?**
Made the links dynamic, now it will route to the contributor's profile.

- **Does this PR introduce a breaking change?** (i.e changes that may require users to update/refactor existing istances of the application)
No

❤️ Thank you!
